### PR TITLE
feat(worker-dashboard): calendario mensual estilo planning; festivos (sáb+dom+oficiales); rangos completos y sin parpadeoDevelop new

### DIFF
--- a/src/app/worker-dashboard/schedule/page.tsx
+++ b/src/app/worker-dashboard/schedule/page.tsx
@@ -465,7 +465,15 @@ export default function SchedulePage(): React.JSX.Element {
     };
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     load();
-  }, [user?.email]);
+  }, [
+    user?.email,
+    weekRange.start,
+    weekRange.end,
+    nextWeekRange.start,
+    nextWeekRange.end,
+    monthRange.start,
+    monthRange.end,
+  ]);
 
   const formatLongDate = (d: Date): string =>
     d.toLocaleDateString('es-ES', {


### PR DESCRIPTION
Contexto: La vista de horario de trabajadora necesitaba reflejar correctamente los días de trabajo para “festivos”, “laborables” y “flexible”, y contar los servicios del mes completo sin desfases ni parpadeos. Además, faltaba la vista mensual coherente con el Planning del panel admin.
Cambios principales:
Festivos: ahora incluyen sábado, domingo y festivos oficiales; se añade fallback para el 15/08.
Rangos correctos:
“Este mes” usa el mes completo (1→último día).
“Esta semana” usa la semana actual (lunes→domingo).
Mitigación de parpadeo en “Esta semana” y “Este mes”.
Claves de fecha estables (formato local YYYY-MM-DD) para evitar desfases por UTC.
Calendario mensual en worker-dashboard/schedule:
Estilo Planning, mes 1→último día (sin arrastrar días de otros meses).
Borde rojo en festivos/fines de semana; anillo azul en el día actual.
Muestra hasta 4 servicios por día.
Cabecera con labels de días de la semana en escritorio; etiquetas cortas dentro de la celda en móvil/tablet.
Conteos de Próximos servicios del Dashboard corregidos:
“Este mes” contabiliza 11 para una trabajadora de “festivos” en agosto.
“Esta semana” usa la semana actual.
Detalles técnicos:
Normalización de claves de fecha a formato local.
Consulta de festivos desde holidays y fallback para el 15/08.
Lógica shouldWorkOnDate unificada: “festivos” (sábado/domingo/festivo), “laborables” (L-V no festivo), “flexible” (todos los días).
En el calendario mensual se construye un grid del mes exacto (no 6x7 arrastrando otros meses) para coherencia visual.
Cómo probar:
Ir a worker-dashboard y comprobar:
“Próximos servicios”: valores coherentes (p.ej., agosto “festivos” = 11).
Ir a worker-dashboard/this-week:
Ver que no hay parpadeo y que el 15/08 se marca como festivo.
Ir a worker-dashboard/this-month:
Ver semanas rotuladas dentro del mes (ya no 31 jul o 7 sep).
Ir a worker-dashboard/schedule:
Selector “Semana/Mes”.
En “Mes”: ver el calendario 1→último día, borde rojo en festivos/fines de semana, anillo azul en el día actual, cabecera con días de la semana en escritorio.
Checklist:
[x] 0 errores y 0 warnings en lint
[x] Type-check OK
[x] Formato Prettier OK
[x] Sin console.log, sin imports/variables no usados
[x] Estilo mobile-first y accesibilidad básica
[x] Consistencia visual con Planning
Impacto:
No hay cambios de esquema de datos.
Usa la tabla holidays existente (Mataró) para festivos oficiales.
Riesgos/Mitigación:
Si un festivo local no está en holidays, el fallback cubre el 15/08, pero conviene mantener la tabla actualizada para otros días locales.
Notas:
Se recomienda probar en navegador en escritorio y móvil para validar la cabecera de días y el anillo azul del día actual.
